### PR TITLE
Added support for CI

### DIFF
--- a/.abstruse.yml
+++ b/.abstruse.yml
@@ -1,0 +1,10 @@
+image: ubuntu:20.04
+
+script:
+ - apt update
+ - DEBIAN_FRONTEND=noninteractive apt install -y git build-essential cmake libuv1-dev libzmq3-dev libsodium-dev libpgm-dev libnorm-dev libgss-dev
+
+ - mkdir build && cd build && cmake .. && make -j2
+ - cp build/p2pool /archive/p2pool_$ABSTRUSE_BRANCH
+ - git show | head -3 > /archive/p2pool_$ABSTRUSE_BRANCH.gitinfo
+ - sha512sum build/p2pool > /archive/p2pool_$ABSTRUSE_BRANCH.sha512sum


### PR DESCRIPTION
Hey! I've setup a CI to build a binary of p2pool on Abstruse CI.

 - You can have a fancy badge now [![Build Status](https://ci.mrcyjanek.net/badge/80f7925a?branch=master)](https://static.mrcyjanek.net/abstruse/p2pool/)
 - Your users don't need to compile p2pool just to test it, downloads, sha512sum and git commit for each branch is available: https://static.mrcyjanek.net/abstruse/p2pool/

