### PR TITLE
Add doc section for Arch Linux AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ git submodule sync && git submodule update --init --force --recursive
 make release-static -j$(nproc)
 ```
 
+### Arch Linux [AUR](https://wiki.archlinux.org/title/Arch_User_Repository)
+
+Make the package: [p2pool-git](https://aur.archlinux.org/packages/p2pool-git/)
+
 ### macOS
 
 p2pool binary:


### PR DESCRIPTION
Successfully built on Arch Linux. x86_64 AMD.

This PR is to tell new users there is a package for Arch Linux now that I'm maintaining over there. Any build issues I'm now actively maintaining for this package. I'll try and include a systemd service over there too so users can run p2pool at startup along with monerod/xmrig. Of course they will need to set that up themselves. I'm only handling p2pool here.