### PR TITLE
Add build for Nix/NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Make the package: [p2pool-git](https://aur.archlinux.org/packages/p2pool-git/)
 ### [Nix/NixOS](https://nixos.org)
 
 This is a flake only project. So you have to use [nixUnstable with nix flakes](https://nixos.wiki/wiki/Flakes) to build or install p2pool. 
-The commands below use the new flake specific reference-format, so be sure to also set `ca-refernces` in `--experimental-features`.
+The commands below use the new flake specific reference-format, so be sure to also set `ca-references` in `--experimental-features`.
 
 Because this project has submodules which are not fixed in _nixUnstable_ yet you have to use the `nix/master` branch:
 ```

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ nix shell github:nixos/nix/master
 
 Run the binary:
 ```
-nix run github:SChernykh/p2pool
+nix run git+https://github.com/SChernykh/p2pool?ref=master
 ```
 
 Run the binary with arguments:
 ```
-nix run github:SChernykh/p2pool -- --help
+nix run git+https://github.com/SChernykh/p2pool?ref=master -- --help
 ```
 
 ### macOS

--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ make release-static -j$(nproc)
 
 Make the package: [p2pool-git](https://aur.archlinux.org/packages/p2pool-git/)
 
+### [Nix/NixOS](https://nixos.org)
+
+This is a flake only project. So you have to use [nixUnstable with nix flakes](https://nixos.wiki/wiki/Flakes) to build or install p2pool. 
+The commands below use the new flake specific reference-format, so be sure to also set `ca-refernces` in `--experimental-features`.
+
+Because this project has submodules which are not fixed in _nixUnstable_ yet you have to use the `nix/master` branch:
+```
+nix shell github:nixos/nix/master
+```
+
+Run the binary:
+```
+nix run github:SChernykh/p2pool
+```
+
+Run the binary with arguments:
+```
+nix run github:SChernykh/p2pool -- --help
+```
+
 ### macOS
 
 p2pool binary:

--- a/flake.lock
+++ b/flake.lock
@@ -17,7 +17,23 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1629481132,
+        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1631368560,
+        "narHash": "sha256-JUx+2uf1C2dZ1n56hcy5gjPGh4UP0nQwIr+WbjaWaP4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "91333fe5c9212e1a0c587c8ce70b0571bf0b18bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "Decentralized pool for Monero mining.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+  };
+
+  outputs = { self, nixpkgs }: {
+    packages.x86_64-linux.p2pool =  with import nixpkgs { system = "x86_64-linux";}; stdenv.mkDerivation {
+      pname = "p2pool";
+      version = "0.0.1";
+      src = self;
+
+      nativeBuildInputs = [ cmake pkg-config ];
+
+      buildInputs = [
+        libuv zeromq
+        libsodium gss
+      ];
+
+      installPhase = ''
+        mkdir -p $out/bin
+        cp -r ./p2pool $out/bin/
+      '';
+    };
+
+    defaultPackage.x86_64-linux = self.packages.x86_64-linux.p2pool;
+  };
+}


### PR DESCRIPTION
This adds build instructions for [NixOS](https://nixos.org) and the flake files to go along with it. 

I found that I can omit the `libpgm-dev` and `libnorm-dev` dependency. I tried this because I didn't found those in nixpkgs. Somehow it builds and works regardless. 