### PR TITLE
Proposed changes for Raspberry Pi 4 armv7l builds

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -77,7 +77,11 @@
 
 #endif
 
+#include <boost/multiprecision/cpp_int.hpp>
+
 namespace p2pool {
+
+using uint128_t = boost::multiprecision::uint128_t;
 
 constexpr size_t HASH_SIZE = 32;
 constexpr uint8_t HARDFORK_SUPPORTED_VERSION = 14;
@@ -97,14 +101,18 @@ constexpr uint8_t TX_EXTRA_MERGE_MINING_TAG = 3;
 #else
 FORCEINLINE uint64_t umul128(uint64_t a, uint64_t b, uint64_t* hi)
 {
-	const unsigned __int128 r = static_cast<unsigned __int128>(a) * static_cast<unsigned __int128>(b);
-	*hi = r >> 64;
+	const uint128_t r = static_cast<uint128_t>(a) * static_cast<uint128_t>(b);
+      uint128_t higher = static_cast<uint128_t>(*hi);
+	higher = r >> 64;
+      *hi = static_cast<uint64_t>(higher);
 	return static_cast<uint64_t>(r);
 }
 
 FORCEINLINE uint64_t udiv128(uint64_t hi, uint64_t lo, uint64_t divisor, uint64_t* remainder)
 {
-	const unsigned __int128 n = (static_cast<unsigned __int128>(hi) << 64) + lo;
+      const uint128_t dividend = static_cast<uint128_t>(hi);
+      const uint128_t shifted = (dividend << 64) + static_cast<uint128_t>(lo);
+      const uint64_t n = static_cast<uint64_t>(shifted);
 
 	const uint64_t result = n / divisor;
 	*remainder = n % divisor;
@@ -170,7 +178,7 @@ struct difficulty_type
 #ifdef _MSC_VER
 		_addcarry_u64(_addcarry_u64(0, lo, b.lo, &lo), hi, b.hi, &hi);
 #elif __GNUC__
-		*reinterpret_cast<unsigned __int128*>(this) += *reinterpret_cast<const unsigned __int128*>(&b);
+              *reinterpret_cast<uint128_t*>(this) += *reinterpret_cast<const uint128_t*>(&b);
 #else
 		const uint64_t t = lo;
 		lo += b.lo;

--- a/src/log.h
+++ b/src/log.h
@@ -15,6 +15,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "util.h"
 #pragma once
 
 namespace p2pool {
@@ -170,6 +171,7 @@ INT_ENTRY(uint8_t)
 INT_ENTRY(uint16_t)
 INT_ENTRY(uint32_t)
 INT_ENTRY(uint64_t)
+INT_ENTRY(long int)
 
 #ifdef __APPLE__
 INT_ENTRY(long)


### PR DESCRIPTION
Hello, and thank you very much for this phenomenal project!

I have been attempting to build the binaries for this on a Raspberry Pi 4 armv7l environment, and currently receive the following errors:

```
p2pool/src/common.h:100:17: error: expected unqualified-id before ‘__int128’
  const unsigned __int128 r = static_cast<unsigned __int128>(a) * static_cast<unsigned __int128>(b);
                 ^~~~~~~~
p2pool/src/common.h:101:8: error: ‘r’ was not declared in this scope                                *hi = r >> 64;
        ^
p2pool/src/common.h:98:39: error: unused parameter ‘a’ [-Werror=unused-parameter]
 FORCEINLINE uint64_t umul128(uint64_t a, uint64_t b, uint64_t* hi)
                              ~~~~~~~~~^
p2pool/src/common.h:98:51: error: unused parameter ‘b’ [-Werror=unused-parameter]
 FORCEINLINE uint64_t umul128(uint64_t a, uint64_t b, uint64_t* hi)
                                          ~~~~~~~~~^
p2pool/src/common.h: In function ‘uint64_t p2pool::udiv128(uint64_t, uint64_t, uint64_t, uint64_t*
)’:
p2pool/src/common.h:107:17: error: expected unqualified-id before ‘__int128’
  const unsigned __int128 n = (static_cast<unsigned __int128>(hi) << 64) + lo;
                 ^~~~~~~~
p2pool/src/common.h:109:26: error: ‘n’ was not declared in this scope
  const uint64_t result = n / divisor;
                          ^
p2pool/src/common.h:105:39: error: unused parameter ‘hi’ [-Werror=unused-parameter]
 FORCEINLINE uint64_t udiv128(uint64_t hi, uint64_t lo, uint64_t divisor, uint64_t* remainder)
                              ~~~~~~~~~^~
p2pool/src/common.h:105:52: error: unused parameter ‘lo’ [-Werror=unused-parameter]
 FORCEINLINE uint64_t udiv128(uint64_t hi, uint64_t lo, uint64_t divisor, uint64_t* remainder)
                                           ~~~~~~~~~^~
p2pool/src/common.h: In member function ‘p2pool::difficulty_type& p2pool::difficulty_type::operato
r+=(const p2pool::difficulty_type&)’:
p2pool/src/common.h:173:30: error: expected ‘>’ before ‘__int128’
   *reinterpret_cast<unsigned __int128*>(this) += *reinterpret_cast<const unsigned __int128*>(&b);
                              ^~~~~~~~
p2pool/src/common.h:173:30: error: expected ‘(’ before ‘__int128’
   *reinterpret_cast<unsigned __int128*>(this) += *reinterpret_cast<const unsigned __int128*>(&b);
                              ^~~~~~~~
                              (
p2pool/src/common.h:173:30: error: expected primary-expression before ‘__int128’
   *reinterpret_cast<unsigned __int128*>(this) += *reinterpret_cast<const unsigned __int128*>(&b);
                              ^~~~~~~~                                                                                                            p2pool/src/common.h:173:29: error: expected ‘)’ before ‘__int128’
   *reinterpret_cast<unsigned __int128*>(this) += *reinterpret_cast<const unsigned __int128*>(&b);
                             ^~~~~~~~~
                             )
p2pool/src/common.h:168:65: error: unused parameter ‘b’ [-Werror=unused-parameter]
  FORCEINLINE difficulty_type& operator+=(const difficulty_type& b)
```

Please note that I attempt to build this by following the instructions on the GitHub Project page:

```bash
git clone --recursive https://github.com/SChernykh/p2pool
cd p2pool
mkdir build && cd build
cmake ..
make -j$(nproc)
```

I have managed to have this successfully build by introducing the changes found in these commits, which essentially:

- Use `boost::multiprecision::uint128_t` in `umul128`, `udiv128`, and `difficulty_type +=` for handling 32-bit processor architectures
- Ensure that `long int` is handled for `Stream::Entry<T>`

I apologize if this architecture should *not* be supported, or should there be any errors or oversights in my proposed changes. Thank you very much again for your labor and time. Cheers!