### PR TITLE
Display stratum user on SHARE FOUND and "client found mainchain block" log entries

### DIFF
--- a/src/stratum_server.h
+++ b/src/stratum_server.h
@@ -65,6 +65,7 @@ public:
 
 		uint32_t m_perConnectionJobId;
 		difficulty_type m_customDiff;
+		std::string m_customUser;
 	};
 
 	bool on_login(StratumClient* client, uint32_t id, const char* login);
@@ -77,6 +78,7 @@ private:
 	void print_stratum_status() const;
 
 	static bool get_custom_diff(const char* s, difficulty_type& diff);
+	static bool get_custom_user(const char* s, std::string& user);
 
 	static void on_share_found(uv_work_t* req);
 	static void on_after_share_found(uv_work_t* req, int status);


### PR DESCRIPTION
Fetch user part of the stratum client, then display it on messages related to shares found. This includes anything until the first `+` or `.`.

The user is only shown when not empty. Only printable ASCII characters are allowed, to prevent inclusion of any ANSI escape codes. 

Examples:

```
NOTICE  2021-10-19 13:43:36.1255 StratumServer SHARE FOUND: mainchain height 2474392, diff 690280934, client 127.0.0.1:48772 user xmrig-proxy, effort 461.075%
```

```
NOTICE  NOTICE  2021-10-19 13:13:13.1313 StratumServer client 123.123.123.123:44798 user xmrig-proxy found a mainchain block, submitting it
```