### PR TITLE
Monero latest release supports p2pool

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -18,8 +18,8 @@ P2POOL_VOLUME=p2pool
 ##
 # Monero Node Settings
 #
-# Version of Monero to build
-MONERO_GIT_TAG=release-v0.17
+# Version of Monero to build. Must be v0.17.3.0 or later for p2pool support. "latest" pulls the most recent release tag
+MONERO_GIT_TAG=latest
 #
 # Limit the size of the blockchain on disk (comment to disable)
 PRUNE_NODE="--prune-blockchain"

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -18,7 +18,7 @@ git clone --recursive https://github.com/SChernykh/p2pool
 cd p2pool/docker-compose
 vi .env
 ```
-<b>WALLET_ADDRESS</b> is the only setting that needs to be updated in that file
+**WALLET_ADDRESS** is the only setting that needs to be updated in that file
 
 #### Build the docker containers
 ```
@@ -31,8 +31,19 @@ docker-compose up
 ```
 
 #### Optional
-* You can run everythng in the background by adding the "-d" argument to the "docker-compose up" command: ```docker-compose up -d```
-* You can see logs when running in the background for with the "docker logs" command:  ```docker logs -f p2pool-xmrig``` or ```docker logs -f p2pool-p2pool``` or ```docker logs -f p2pool-monero```
 * Open ports 18080 (Monero p2p port) and 37889 (P2Pool p2p port) in your firewall to ensure better connectivity. If you're mining from a computer behind NAT (like a router) you could consider forwarding the ports to your local machine
 * An XMRig CPU miner is included by default, but you can connect additional miners to this same p2pool node using port 3333
 * Configure your kernel for maximum mining performance: [XMRig RandomX Optimization Guide](https://xmrig.com/docs/miner/randomx-optimization-guide)
+
+
+#### Other usefull commands
+* You can **run everythng in the background** by adding the "-d" argument to the "docker-compose up" command: ```docker-compose up -d```
+* You can **stop everything** with CTRL-C or ```docker-compose down```
+* You can see logs when running in the background for with the "docker logs" command:  ```docker logs -f p2pool-xmrig``` or ```docker logs -f p2pool-p2pool``` or ```docker logs -f p2pool-monero```
+
+
+#### Uninstall
+Change to p2pool/docker-compose directory
+Stop and remove all containers: ```docker-compose down```
+Remove the p2pool data: ```docker volume rm p2pool```
+Remove the monero data: ```docker volume rm monero```

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,3 +1,4 @@
+---
 version: '3.4'
 
 networks:
@@ -67,8 +68,6 @@ services:
     networks:
       - p2pool
     privileged: true
-    cap_add:
-      - ALL
     volumes:
       - /dev:/dev:ro
       - /lib/modules:/lib/modules:ro

--- a/docker-compose/monero/Dockerfile
+++ b/docker-compose/monero/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:latest
-ARG MONERO_GIT_TAG="master"
+ARG MONERO_GIT_TAG="latest"
 
 RUN set -e && \
     apt-get update -q -y --no-install-recommends && \
@@ -47,6 +47,7 @@ RUN set -e && \
 WORKDIR /usr/src
 RUN git clone --recursive https://github.com/monero-project/monero && \
     cd monero && \
+    if [ "x$MONERO_GIT_TAG" = "xlatest" ]; then MONERO_GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1)); fi && \
     git checkout $MONERO_GIT_TAG && \
     git submodule sync && git submodule update --init --force --recursive && \
     make release-static -j$(nproc)
@@ -54,9 +55,8 @@ RUN git clone --recursive https://github.com/monero-project/monero && \
 # ---
 
 FROM ubuntu:latest
-ARG MONERO_GIT_TAG="master"
 
-COPY --from=0 /usr/src/monero/build/Linux/$MONERO_GIT_TAG/release/bin/* /
+COPY --from=0 /usr/src/monero/build/Linux/*/release/bin/* /
 
 RUN set -e && \
     apt-get update -q -y --no-install-recommends && \


### PR DESCRIPTION
Latest Monero release tag begins support of p2pool.
Allow a specific release tag, or "latest" to get the most recent automatically (default)
A few more docker commands in the README
