### PR TITLE
Add monero.com to list of compatible wallets

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This guide assumes that you run everything on the same machine. If it's not the 
 - Official Monero CLI and GUI v0.17.2.3 and newer
 - Monerujo v2.1.0 "Vertant" and newer
 - Cake Wallet v4.2.7 and newer
+- Monero.com by Cake Wallet
 - Feather Wallet v1.0.0 and newer
 - MyMonero
 
@@ -106,7 +107,7 @@ Step-by-step guide:
 *NOTE: Windows SmartScreen may block incoming connections by files that are "Downloaded from the Internet". You can allow 'p2pool.exe' and 'monerod.exe' by double-clicking them, clicking "More Info", then click "Run Anyway" and then closing them immediately so you can run them from the command line. Advanced users can use the PowerShell cmdlet `Unblock-File` to remove this flag.*
 
 - Download p2pool binaries from https://github.com/SChernykh/p2pool/releases/latest
-- Download xmrig binary from https://github.com/xmrig/xmrig/releases/latest
+- Download xmrig binary from https://github.com/xmrig/xmrig/releases/latest *(xmrig-6.15.2-gcc-win64.zip is the current version)*
 - Expand the p2pool binaries into an appropriate location (`%USERPROFILE%/bin` or `C:/bin/` are good options)
 - Expand xmrig binary into appropriate location (same folder as p2pool is fine)
 - Prepare huge pages (each of monerod/p2pool/xmrig needs them): 


### PR DESCRIPTION
Monero.com used the 4.2.8 Cake Wallet base, so all versions of that app are compatible