### PR TITLE
ARM Cortex A-53 / 72 errata mitigations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,99 @@ if (WITH_RANDOMX)
 	set(LIBS randomx)
 endif()
 
+if (NOT ARCH OR ARCH STREQUAL "" OR ARCH STREQUAL "native" OR ARCH STREQUAL "default")
+  set(ARCH_ID "${CMAKE_SYSTEM_PROCESSOR}")
+else()
+  set(ARCH_ID "${ARCH}")
+endif()
+
+if (ARCH_ID STREQUAL "aarch64")
+  set(ARM 1)
+  set(ARM8 1)
+endif()
+
+if(WIN32 OR ARM)
+  set(OPT_FLAGS_RELEASE "-O2")
+endif()
+
+if(ARM)
+  message(STATUS "Setting FPU Flags for ARM Processors")
+  include(TestCXXAcceptsFlag)
+
+  #NB NEON hardware does not fully implement the IEEE 754 standard for floating-point arithmetic
+  #Need custom assembly code to take full advantage of NEON SIMD
+
+  #Cortex-A5/9  -mfpu=neon-fp16
+  #Cortex-A7/15 -mfpu=neon-vfpv4
+  #Cortex-A8    -mfpu=neon
+  #ARMv8  	  -FP and SIMD on by default for all ARM8v-a series, NO -mfpu setting needed
+
+  #For custom -mtune, processor IDs for ARMv8-A series:
+  #0xd04 - Cortex-A35
+  #0xd07 - Cortex-A57
+  #0xd08 - Cortex-A72
+  #0xd03 - Cortex-A73
+
+  if(NOT ARM8)
+    CHECK_CXX_ACCEPTS_FLAG(-mfpu=vfp3-d16 CXX_ACCEPTS_VFP3_D16)
+    CHECK_CXX_ACCEPTS_FLAG(-mfpu=vfp4 CXX_ACCEPTS_VFP4)
+    CHECK_CXX_ACCEPTS_FLAG(-mfloat-abi=hard CXX_ACCEPTS_MFLOAT_HARD)
+    CHECK_CXX_ACCEPTS_FLAG(-mfloat-abi=softfp CXX_ACCEPTS_MFLOAT_SOFTFP)
+  endif()
+
+  if(ARM8)
+    CHECK_CXX_ACCEPTS_FLAG(-mfix-cortex-a53-835769 CXX_ACCEPTS_MFIX_CORTEX_A53_835769)
+    CHECK_CXX_ACCEPTS_FLAG(-mfix-cortex-a53-843419 CXX_ACCEPTS_MFIX_CORTEX_A53_843419)
+  endif()
+
+  if(ARM6)
+    message(STATUS "Selecting VFP for ARMv6")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=vfp")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=vfp")
+  endif(ARM6)
+
+  if(ARM7)
+    if(CXX_ACCEPTS_VFP3_D16 AND NOT CXX_ACCEPTS_VFP4)
+      message(STATUS "Selecting VFP3 for ARMv7")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=vfp3-d16")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=vfp3-d16")
+    endif()
+
+    if(CXX_ACCEPTS_VFP4)
+      message(STATUS "Selecting VFP4 for ARMv7")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfpu=vfp4")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=vfp4")
+    endif()
+
+    if(CXX_ACCEPTS_MFLOAT_HARD)
+      message(STATUS "Setting Hardware ABI for Floating Point")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfloat-abi=hard")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfloat-abi=hard")
+    endif()
+
+    if(CXX_ACCEPTS_MFLOAT_SOFTFP AND NOT CXX_ACCEPTS_MFLOAT_HARD)
+      message(STATUS "Setting Software ABI for Floating Point")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfloat-abi=softfp")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfloat-abi=softfp")
+    endif()
+  endif(ARM7)
+
+  if(ARM8)
+    if(CXX_ACCEPTS_MFIX_CORTEX_A53_835769)
+      message(STATUS "Enabling Cortex-A53 workaround 835769")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfix-cortex-a53-835769")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfix-cortex-a53-835769")
+    endif()
+
+    if(CXX_ACCEPTS_MFIX_CORTEX_A53_843419)
+      message(STATUS "Enabling Cortex-A53 workaround 843419")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mfix-cortex-a53-843419")
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfix-cortex-a53-843419")
+    endif()
+  endif(ARM8)
+
+endif(ARM)
+
 include(cmake/flags.cmake)
 
 set(HEADERS


### PR DESCRIPTION
Applicable to all ARM A-53 single board computers but primarily targeted at Raspberry Pi 3&4 users as those will be the most numerous:

There are known faults at the chip level with ARM Cortex A-53, as per the Arm Developer errata notice [developer.arm.com/documentation](https://developer.arm.com/documentation/epm048406/2100/) where:

**835769:** AArch64 multiply-accumulate instruction might produce incorrect result (page 20 of that document)
and
**843419:** A load or store might access an incorrect address (page 22)

To mitigate for this gcc has additional build flags:

https://gcc.gnu.org/onlinedocs/gcc.pdf (Page 315)

-mfix-cortex-a53-835769
-mno-fix-cortex-a53-835769
_Enable or disable the workaround for the ARM Cortex-A53 erratum number
835769. This involves inserting a NOP instruction between memory instructions
and 64-bit integer multiply-accumulate instructions._

-mfix-cortex-a53-843419
-mno-fix-cortex-a53-843419
_Enable or disable the workaround for the ARM Cortex-A53 erratum number
843419. This erratum workaround is made at link time and this will only pass
the corresponding flag to the linker._

Which Monero implemented:

[monero-project/monero/commit/cf10e05cc6a0ed495dbdd44ec3a76b964b14edba](https://github.com/monero-project/monero/commit/cf10e05cc6a0ed495dbdd44ec3a76b964b14edba)

And can be seen working/triggered as during build.

Is this applicable through any of the pools verification functions?