### PR TITLE
support monero v0.18.0.0 and minor fixes

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -24,7 +24,7 @@ Make sure to set your own monero **Wallet Address**.  The default is to donate m
 
 #### Build the docker containers
 ```
-docker compose build
+docker compose build --no-cache
 ```
 
 #### Run the node, pool, and CPU miner (or updated configuration)
@@ -42,7 +42,8 @@ docker compose up
 #### Other usefull commands
 * You can **run everything in the background** by adding the "-d" argument to the "docker compose up" command: ```docker compose up -d```
 * You can **stop everything** with CTRL-C or ```docker compose down```
-* You can see logs when running in the background for with the "docker logs" command:  ```docker logs -f p2pool-xmrig``` or ```docker logs -f p2pool-p2pool``` or ```docker logs -f p2pool-monero```
+* You can **update** by building new images with the ```--no-cache``` option.  Example: ```docker compose build --no-cache``` or just update Monero with: ```docker compose build --no-cache monero``` followed by ```docker compose up```
+* You can see logs when running in the background for with the "docker compose logs" command:  ```docker compose logs -f```
 * You can pause mining with: ```docker compose pause xmrig``` and resume mining with: ```docker compose unpause xmrig```
 * You can disable mining with: ```docker compose stop xmrig``` and re-enable mining with: ```docker compose start xmrig```
 * You can view your Server Statistics using a web browser if you enabled that feature in the configuration at: http://localhost:3380 (or alternate port as configured)
@@ -52,4 +53,5 @@ docker compose up
 Change to p2pool/docker-compose directory <br />
 Stop and remove all containers: ```docker compose down``` <br />
 Remove the p2pool data: ```docker volume rm p2pool``` <br />
+Remove the p2pool-mini data: ```docker volume rm p2pool-mini``` <br />
 Remove the monero data: ```docker volume rm monero```

--- a/docker-compose/cfg/docker-compose.jinja2
+++ b/docker-compose/cfg/docker-compose.jinja2
@@ -7,7 +7,12 @@ networks:
 
 volumes:
   p2pool: 
+{% if sidechain[0] == 0 %}
     name: p2pool
+{% else %}
+    name: p2pool-mini
+{% endif %}
+
 {% if configure_monero == True %}
   monero:
     name: monero

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -7,7 +7,10 @@ networks:
 
 volumes:
   p2pool: 
+
     name: p2pool
+
+
 
   monero:
     name: monero
@@ -32,8 +35,7 @@ services:
       - /dev/hugepages:/dev/hugepages:rw
 
     depends_on:
-      monero:
-        condition: service_healthy
+      - monero
 
     restart: unless-stopped
     command: >-
@@ -90,11 +92,6 @@ services:
       - /dev/null:/home/monero/.bitmonero/bitmonero.log:rw
       - /dev/hugepages:/dev/hugepages:rw
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "18081"]
-      interval: 2s
-      timeout: 1s
-      start_period: 10s
     command: >-
       --zmq-pub tcp://0.0.0.0:18083
       --disable-dns-checkpoints

--- a/docker-compose/monero/Dockerfile
+++ b/docker-compose/monero/Dockerfile
@@ -1,81 +1,59 @@
-FROM ubuntu:20.04
+# Multistage docker build, requires docker 17.05
+
+# builder stage
+FROM ubuntu:20.04 as builder
 ARG MONERO_GIT_TAG="latest"
 
 RUN set -e && \
     apt-get update -q -y --no-install-recommends && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -q -y --no-install-recommends \
-        git \
-        ca-certificates \
+        automake \
+        autotools-dev \
+        bsdmainutils \
         build-essential \
-        pkg-config \
-        cmake \
-        libuv1-dev \
-        libzmq3-dev \
-        libsodium-dev \
-        libpgm-dev \
-        libnorm-dev \
-        libgss-dev \
-        libssl-dev \
-        libzmq3-dev \
-        libunbound-dev \
-        libsodium-dev \
-        libunwind8-dev \
-        liblzma-dev \
-        libreadline6-dev \
-        libldns-dev \
-        libexpat1-dev \
-        libpgm-dev \
-        qttools5-dev-tools \
-        libhidapi-dev \
-        libusb-1.0-0-dev \
-        libprotobuf-dev \
-        protobuf-compiler \
-        libudev-dev \
-        libboost-chrono-dev \
-        libboost-date-time-dev \
-        libboost-filesystem-dev \
-        libboost-locale-dev \
-        libboost-program-options-dev \
-        libboost-regex-dev \
-        libboost-serialization-dev \
-        libboost-system-dev \
-        libboost-thread-dev \
+        ca-certificates \
         ccache \
-        doxygen \
-        graphviz
+        cmake \
+        curl \
+        git \
+        libtool \
+        pkg-config \
+        gperf
 
-WORKDIR /usr/src
+
+WORKDIR /src
 RUN git clone --recursive https://github.com/monero-project/monero && \
     cd monero && \
     if [ "x$MONERO_GIT_TAG" = "xlatest" ]; then MONERO_GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1)); fi && \
     git checkout $MONERO_GIT_TAG && \
     git submodule sync && git submodule update --init --force --recursive && \
-    make release-static -j$(nproc)
+    make -j$(nproc) depends target=$(contrib/depends/config.guess)
 
 # ---
 
+# runtime stage
 FROM ubuntu:20.04
 
-COPY --from=0 /usr/src/monero/build/Linux/*/release/bin/* /
+COPY --from=0 /src/monero/build/*/release/bin /usr/local/bin/
 
 RUN set -e && \
     apt-get update -q -y --no-install-recommends && \
     DEBIAN_FRONTEND="noninteractive" apt-get install -q -y --no-install-recommends \
-    libgssapi-krb5-2 \
-    netcat \
-      && \
+      ca-certificates \
+      netcat \
+    && \
     apt-get clean && \
     rm -rf /var/lib/apt
 
 RUN groupadd -r monero -g 1000 && \
-    useradd -u 1000 -r -g monero -s /sbin/nologin -c "monero node user" monero
-RUN mkdir -p /home/monero/.bitmonero && \
-    chown monero.monero /home/monero /home/monero/.bitmonero
+    adduser --uid 1000 --gid 1000 --system --disabled-password monero && \
+	mkdir -p /home/monero/.bitmonero && \
+	chown -R monero:monero /home/monero/.bitmonero
+
 USER monero
+WORKDIR /home/monero
 
 EXPOSE 18080 18081 18083
-
 VOLUME /home/monero/.bitmonero
 
-WORKDIR /home/monero
-ENTRYPOINT ["/monerod"]
+ENTRYPOINT ["/usr/local/bin/monerod"]

--- a/docker-compose/statistics/app/templates/index.html
+++ b/docker-compose/statistics/app/templates/index.html
@@ -12,13 +12,13 @@
     <script src="{{url_for('static', filename='bootstrap.min.js')}}"></script>
     <div style="text-align:center;">
       <img src="{{url_for('static', filename='monero-symbol-480.png')}}" width="75px" height="75px" alt="Monero"/>
-      <h1 style="color: #FFA500;">P2Pool Server Statistics</h1>
+      <h1 style="color: #FF6600;">P2Pool Server Statistics</h1>
     </div>
  
     <div class="card-group">
       <div class="col-sm-4 grid-margin stretch-card">
         <div class="card">
-          <div class="card-header text-black mb-1 pb-1" style="background-color: #FFA500;"><h2>Local Pool</h2></div>
+          <div class="card-header text-black mb-1 pb-1" style="text-align: center; background-color: #FF6600;"><h2>Local Pool</h2></div>
           <div class="card-body mb-0 pb-0">
             <h6 class="card-subtitle text-muted" style="font-size:80%;">(note: stats reset on restart)</h6>
             <div class="table-responsive table-hover table-condensed table-striped">
@@ -54,7 +54,7 @@
                   </tr>
                   <tr>
                     <td>Miner Connections</td>
-                    <td>{{ local_stats["incoming_connections"] }}<td>
+                    <td>{{ local_stats["incoming_connections"] }}</td>
                   </tr>
                 </tbody>
               </table>
@@ -65,7 +65,7 @@
   
       <div class="col-sm-4 grid-margin stretch-card">
         <div class="card">
-          <div class="card-header text-black mb-1 pb-1" style="background-color: #FFA500;"><h2>Global Pool</h2></div>
+          <div class="card-header text-black mb-1 pb-1" style="text-align: center; background-color: #FF6600;"><h2>Global Pool</h2></div>
           <div class="card-body mb-0 pb-0">
             <h6 class="card-subtitle text-muted" style="font-size:80%;">&nbsp;</h6>
             <div class="table-responsive table-hover table-condensed table-striped">
@@ -116,7 +116,7 @@
   
       <div class="col-sm-4 grid-margin stretch-card">
         <div class="card">
-          <div class="card-header text-black mb-1 pb-1" style="background-color: #FFA500;"><h2>Monero Network</h2></div>
+          <div class="card-header text-black mb-1 pb-1" style="text-align: center; background-color: #FF6600;"><h2>Monero Network</h2></div>
           <div class="card-body mb-0 pb-0">
             <h6 class="card-subtitle text-muted" style="font-size:80%;">&nbsp;</h6>
             <div class="table-responsive table-hover table-condensed table-striped">


### PR DESCRIPTION
Update Monero Dockerfile to build dependency libraries rather than install them using the package manager.  The ubuntu unbound package contained additional dependencies that monero 18 build process doesnt support.  Building the depends will ensure better future compatibility.

Add README instructions for how to build updated images.  Users will need to do this for the monero 18 upgrade.

Use a separate volume for p2pool main vs. p2pool-mini blockchains to allow faster and more reliable switching between the two pools.

Fix default (pre-generated) docker-compose.yml file to remove monero health check code.

Fix syntax error in statistics html

Use a more monero-orange color in statistics web page