### PR TITLE
[request] Support behavior change via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Pool status and monitoring pages can be found at https://p2pool.io/, https://p2p
   - [General Considerations](#general-considerations)
   - [GNU/Linux](#gnulinux)
   - [Windows](#windows)
+  - [Configuration](#configuration)
 - [Build instructions](#build-instructions)
 - [Donations](#donations)
 
@@ -191,6 +192,40 @@ start cmd /k %~dp0\p2pool.exe --wallet YOUR_WALLET_ADDRESS
 ECHO Wait until the daemon shows fully synced before continuing. This can take some time.
 PAUSE
 %~dp0\xmrig.exe -u x+30000 -o 127.0.0.1
+```
+
+### Configuration
+The preferred way to configure P2Pool is the [PLACE_HOLDER_CONFIG_FILE](PLACE_HOLDER_GIT_CONFIG_PATH) as it is more flexible and human friendly.
+
+P2Pool behavior can also be changed with direct command line arguments:
+```
+--wallet             Wallet address to mine to. Subaddresses and integrated addresses are not supported!
+--host               IP address of your Monero node, default is 127.0.0.1
+--rpc-port           monerod RPC API port number, default is 18081
+--zmq-port           monerod ZMQ pub port number, default is 18083 (same port as in monerod's "--zmq-pub" command line parameter)
+--stratum            Comma-separated list of IP:port for stratum server to listen on
+--p2p                Comma-separated list of IP:port for p2p server to listen on
+--addpeers           Comma-separated list of IP:port of other p2pool nodes to connect to
+--light-mode         Don't allocate RandomX dataset, saves 2GB of RAM
+--loglevel           Verbosity of the log, integer number between 0 and 6
+--config             Name of the p2pool config file
+--data-api           Path to the p2pool JSON data (use it in tandem with an external web-server)
+--local-api          Enable /local/ path in api path for Stratum Server and built-in miner statistics
+--stratum-api        An alias for --local-api
+--no-cache           Disable p2pool.cache
+--no-color           Disable colors in console output
+--no-randomx         Disable internal RandomX hasher: p2pool will use RPC calls to monerod to check PoW hashes
+--out-peers N        Maximum number of outgoing connections for p2p server (any value between 10 and 1000)
+--in-peers N         Maximum number of incoming connections for p2p server (any value between 10 and 1000)
+--start-mining N     Start built-in miner using N threads (any value between 1 and 64)
+--mini               Connect to p2pool-mini sidechain. Note that it will also change default p2p port from 37889 to 37888
+--no-autodiff        Disable automatic difficulty adjustment for miners connected to stratum
+--rpc-login          Specify username[:password] required for Monero RPC server
+--help               Show this help message
+
+Example command line:
+
+./p2pool --host 127.0.0.1 --rpc-port 18081 --zmq-port 18083 --wallet YOUR_WALLET_ADDRESS --stratum 0.0.0.0:3333 --p2p 0.0.0.0:37889
 ```
 
 ## Build instructions

--- a/config.json
+++ b/config.json
@@ -12,3 +12,27 @@
 	"pplns_window": 2160,
 	"uncle_penalty": 20
 }
+
+// p2pool configuration settings
+{
+	"wallet": "",
+	"host": "127.0.0.1",
+	"rpc_port": "18081",
+	"zmq_port": "18083",
+	"stratum": "",
+	"p2p": "",
+	"addpeers": "",
+	"light_mode": false,
+	"loglevel": 3,
+	"data_api": "",
+	"local_api": "",
+	"no_cache": false,
+	"no_color": false,
+	"no_randomx": false,
+	"out_peers": 10,
+	"in_peers": 10,
+	"start_mining": null,
+	"mini": false,
+	"no_autodiff": false,
+	"rpc_login": "",
+}

--- a/p2pool.conf
+++ b/p2pool.conf
@@ -1,0 +1,81 @@
+########################
+# P2Pool configuration #
+########################
+
+# Wallet address to mine to. Subaddresses and integrated addresses are not supported!
+# usage: [MONERO_WALLET]
+wallet=
+
+# IP address of your Monero node, default is 127.0.0.1
+# usage: [MONERO_NODE_IP]
+host=
+
+# monerod RPC API port number, default is 18081
+# usage: [RPC_PORT]
+rpc-port=
+
+# monerod ZMQ pub port number, default is 18083 (same port as in monerod's "--zmq-pub" command line parameter)
+# usage: [ZMQ_PORT]
+zmq-port=
+
+# Comma-separated list of IP:port for stratum server to listen on
+# usage: [IP:PORT,IP:PORT,IP:PORT...]
+stratum=
+
+# Comma-separated list of IP:port for p2p server to listen on
+# usage: [IP:PORT,IP:PORT,IP:PORT...]
+p2p=
+
+# Comma-separated list of IP:port of other p2pool nodes to connect to
+# usage: [IP:PORT,IP:PORT,IP:PORT...]
+addpeers=
+
+# Don't allocate RandomX dataset, saves 2GB of RAM
+# usage: [true|false]
+light-mode=
+
+# Verbosity of the log, integer number between 0 and 6, default is 3
+# usage: [0-6]
+loglevel=
+
+# Path to the p2pool JSON data (use it in tandem with an external web-server)
+data-api=
+
+# Enable /local/ path in api path for Stratum Server and built-in miner statistics
+local-api=
+
+# Disable p2pool.cache, default is false
+# usage: [true|false]
+no-cache=
+
+# Disable colors in console output, default is false
+# usage: [true|false]
+no-color=
+
+# Disable internal RandomX hasher: p2pool will use RPC calls to monerod to check PoW hashes, default is false
+# usage: [true|false]
+no-randomx=
+
+# Maximum number of outgoing connections for p2p server
+# usage: [10-1000]
+out-peers=
+
+# Maximum number of incoming connections for p2p server
+# usage: [10-1000]
+in-peers=
+
+# Start built-in miner using N threads
+# usage: [1-64]
+start-mining=
+
+# Connect to p2pool-mini sidechain. Note that it will also change default p2p port from 37889 to 37888, default is false
+# usage: [true|false]
+mini=
+
+# Disable automatic difficulty adjustment for miners connected to stratum, default is false
+# usage: [true|false]
+no-autodiff=
+
+# Specify username[:password] required for Monero RPC server
+# usage: [RPC_USERNAME:RPC_PASSWORD]
+rpc-login=


### PR DESCRIPTION
This is a request for P2Pool to support behavior changes via a config file rather than command line arguments, like XMRig.

PR changes:
1. Add command line arguments in JSON-form to `config.json`
2. Create a regular non-JSON config file: `p2pool.conf`
3. Add a `Configuration` section to `README`

The config files have the current `v2.2.1` options and the values are set to the current defaults. I can remove and squash if `JSON` or `conf` is preferred. The README has a placeholder for the config name too.