### PR TITLE
Allow named pipe as stdin

### DIFF
--- a/src/console_commands.cpp
+++ b/src/console_commands.cpp
@@ -42,6 +42,13 @@ ConsoleCommands::ConsoleCommands(p2pool* pool)
 	, m_readBuf{}
 	, m_readBufInUse(false)
 {
+	uv_handle_type stdin_type = uv_guess_handle(0);
+	LOGINFO(3, "uv_guess_handle returned " << static_cast<int>(stdin_type));
+	if (stdin_type != UV_TTY && stdin_type != UV_NAMED_PIPE) {
+		LOGERR(1, "tty or named pipe is not available");
+		throw std::exception();
+	}
+
 	int err = uv_loop_init(&m_loop);
 	if (err) {
 		LOGERR(1, "failed to create event loop, error " << uv_err_name(err));
@@ -55,8 +62,6 @@ ConsoleCommands::ConsoleCommands(p2pool* pool)
 	}
 	m_shutdownAsync.data = this;
 
-	uv_handle_type stdin_type = uv_guess_handle(0);
-	LOGINFO(3, "uv_guess_handle returned " << (int)stdin_type);
 	if (stdin_type == UV_TTY) {
 		LOGINFO(3, "processing stdin as UV_TTY");
 		err = uv_tty_init(&m_loop, &m_tty, 0, 1);
@@ -64,7 +69,7 @@ ConsoleCommands::ConsoleCommands(p2pool* pool)
 			LOGERR(1, "uv_tty_init failed, error " << uv_err_name(err));
 			throw std::exception();
 		}
-		m_stdin_handle = reinterpret_cast<uv_handle_t*>(&m_tty);
+		m_stdin_handle = reinterpret_cast<uv_stream_t*>(&m_tty);
 	} else if (stdin_type == UV_NAMED_PIPE) {
 		LOGINFO(3, "processing stdin as UV_NAMED_PIPE");
 		err = uv_pipe_init(&m_loop, &m_stdin_pipe, 0);
@@ -72,15 +77,12 @@ ConsoleCommands::ConsoleCommands(p2pool* pool)
 			LOGERR(1, "uv_pipe_init failed, error " << uv_err_name(err));
 			throw std::exception();
 		}
-		m_stdin_handle = reinterpret_cast<uv_handle_t*>(&m_stdin_pipe);
+		m_stdin_handle = reinterpret_cast<uv_stream_t*>(&m_stdin_pipe);
 		err = uv_pipe_open(&m_stdin_pipe, 0);
 		if (err) {
 			LOGERR(1, "uv_pipe_open failed, error " << uv_err_name(err));
 			throw std::exception();
 		}
-	} else {
-		LOGERR(1, "tty or named pipe is not available");
-		throw std::exception();
 	}
 	m_stdin_handle->data = this;
 

--- a/src/console_commands.h
+++ b/src/console_commands.h
@@ -35,6 +35,8 @@ private:
 	uv_loop_t m_loop;
 	uv_async_t m_shutdownAsync;
 	uv_tty_t m_tty;
+	uv_pipe_t m_stdin_pipe;
+	uv_handle_t* m_stdin_handle;
 	uv_thread_t m_loopThread;
 
 	char m_readBuf[64];
@@ -48,7 +50,7 @@ private:
 	{
 		ConsoleCommands* pThis = reinterpret_cast<ConsoleCommands*>(async->data);
 		uv_close(reinterpret_cast<uv_handle_t*>(&pThis->m_shutdownAsync), nullptr);
-		uv_close(reinterpret_cast<uv_handle_t*>(&pThis->m_tty), nullptr);
+		uv_close(reinterpret_cast<uv_handle_t*>(pThis->m_stdin_handle), nullptr);
 	}
 
 	static void allocCallback(uv_handle_t* handle, size_t suggested_size, uv_buf_t* buf);

--- a/src/console_commands.h
+++ b/src/console_commands.h
@@ -36,7 +36,7 @@ private:
 	uv_async_t m_shutdownAsync;
 	uv_tty_t m_tty;
 	uv_pipe_t m_stdin_pipe;
-	uv_handle_t* m_stdin_handle;
+	uv_stream_t* m_stdin_handle;
 	uv_thread_t m_loopThread;
 
 	char m_readBuf[64];


### PR DESCRIPTION
Fixes #237 to allow stdin to be a named pipe in addition to TTY.

# Implementation details
1) `uv_guess_handle(0)` is used to determine the stdin handle type, with alternative handling for `UV_TTY` and `UV_NAMED_PIPE`; any other type produces an error and no console is initiated.
2) For `UV_TTY`, `uv_tty_init()` is used as before. 
3) For `UV_NAMED_PIPE`, `uv_pipe_init()` and `uv_pipe_oepn()` are used to initalise/open the pipe.
4) Separate members are used to store the respective `uv_tty_t` (`m_tty`, not changed) and `uv_pipe_t` (`m_stdin_pipe`) handles; `m_stdin_handle` is used as a `uv_handle_t*` reference to whichever of these was actually used.
5) Code which would needs to use the active handle now uses `m_stdin_handle`, e.g. ` uv_read_start()` and `uv_close()`.

# Testing
Testing done in Linux; not tested in Windows but I can see no reason that it won't work.

## Interactive shell using TTY
When run in interactive shell, console correctly captured, log output:
```
2023-03-07 21:11:55.3621 ConsoleCommands uv_guess_handle, return 14
2023-03-07 21:11:55.3621 ConsoleCommands processing stdin as UV_TTY
2023-03-07 21:11:55.3621 ConsoleCommands event loop started
```
Manually type `exit` in console:
```
2023-03-07 21:12:55.8520 ConsoleCommands event loop stopped
2023-03-07 21:12:55.8521 ConsoleCommands stopped
...
```

## Using named pipe
When used with a service/socket configuration, log output:
```
2023-03-07 12:31:35.5131 ConsoleCommands uv_guess_handle returned 7
2023-03-07 12:31:35.5131 ConsoleCommands processing stdin as UV_NAMED_PIPE
2023-03-07 12:31:35.5133 ConsoleCommands event loop started
```
With `ListenFIFO=/tmp/p2pool.stdin` in socket unit and a correctly configured service, issue command by writing to file:
`echo "status" > /tmp/p2pool.stdin; sleep 1; tail p2pool.log -n 35`, output:
```
Monero node               = <redacted>
Main chain height         = <redacted>
Main chain hashrate       = <redacted>
Side chain ID             = <redacted>
...