### PR TITLE
Disable LTO on NixOS builds

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1631368560,
-        "narHash": "sha256-JUx+2uf1C2dZ1n56hcy5gjPGh4UP0nQwIr+WbjaWaP4=",
+        "lastModified": 1678349056,
+        "narHash": "sha256-kcL7Ap6IfUQRmGFeE2F0SkzIbQaPvZiylIuL2dD6mL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "91333fe5c9212e1a0c587c8ce70b0571bf0b18bd",
+        "rev": "6a231a6eb788a345b265e1f26e04b96d8a402bf5",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "utils": {
       "locked": {
-        "lastModified": 1629481132,
-        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,8 @@
             inherit (pkgs) libuv zeromq libsodium gss curl;
           };
 
+          cmakeFlags = ["-DWITH_LTO=OFF"];
+
           installPhase = ''
             mkdir -p $out/bin
             cp -r ./p2pool $out/bin/


### PR DESCRIPTION
It appears the new 3.x p2pool no longer builds with NixOS:
```
<...>
<artificial>:(.text+0x76f9): undefined reference to `randomx_get_flags'
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40/bin/ld: <artificial>:(.text+0x7718): undefined reference to `randomx_create_vm'
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40/bin/ld: <artificial>:(.text+0x779c): undefined reference to `randomx_vm_set_dataset'
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40/bin/ld: <artificial>:(.text+0x78d5): undefined reference to `randomx_calculate_hash_next'
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40/bin/ld: <artificial>:(.text+0x7a14): undefined reference to `randomx_vm_set_cache'
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40/bin/ld: <artificial>:(.text+0x7c87): undefined reference to `randomx_calculate_hash_first'
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40/bin/ld: <artificial>:(.text+0x82ce): undefined reference to `randomx_destroy_vm'
/nix/store/fhzz4yrdy17czwc9i4swhlpcp445inzb-binutils-2.40/bin/ld: <artificial>:(.text+0x834d): undefined reference to `randomx_create_vm'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/p2pool.dir/build.make:486: p2pool] Error 1
make[1]: *** [CMakeFiles/Makefile2:100: CMakeFiles/p2pool.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

where enabling LTO causes errors in linking. 

Hence, disable LTO for when building with Nix. 