### PR TITLE
Add `gupax.io` to DNS seed nodes

### DIFF
--- a/src/p2p_server.cpp
+++ b/src/p2p_server.cpp
@@ -34,8 +34,8 @@
 LOG_CATEGORY(P2PServer)
 
 static constexpr char saved_peer_list_file_name[] = "p2pool_peers.txt";
-static const char* seed_nodes[] = { "seeds.p2pool.io", "main.p2poolpeers.net", ""};
-static const char* seed_nodes_mini[] = { "seeds-mini.p2pool.io", "mini.p2poolpeers.net", "" };
+static const char* seed_nodes[] = { "seeds.p2pool.io", "main.p2poolpeers.net", "main.gupax.io", "" };
+static const char* seed_nodes_mini[] = { "seeds-mini.p2pool.io", "mini.p2poolpeers.net", "mini.gupax.io", "" };
 
 static constexpr int DEFAULT_BACKLOG = 16;
 static constexpr uint64_t DEFAULT_BAN_TIME = 600;


### PR DESCRIPTION
`main.gupax.io` points to the same nodes as `seeds.p2pool.io`

`mini.gupax.io` same as `seeds-mini.p2pool.io`

Tested on main/mini as-is and with `gupax.io` as the only source.