### PR TITLE
Update Arch Linux package URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ cmake ..
 make -j$(nproc)
 ```
 
-### [Arch Linux](https://archlinux.org/packages/community/x86_64/p2pool/)
+### [Arch Linux](https://archlinux.org/packages/extra/x86_64/p2pool/)
 
 ```
 pacman -S p2pool


### PR DESCRIPTION
The old URL returns 404 now.