### PR TITLE
add miner stats to web server output

### DIFF
--- a/docker-compose/statistics/app/p2pool_statistics.py
+++ b/docker-compose/statistics/app/p2pool_statistics.py
@@ -66,8 +66,10 @@ def render():
             w_list = w.split(",")
             w_list[1] = humanfriendly.format_timespan(int(w_list[1]))
             w_list[2] = human_numbers(int(w_list[2]))
-            w_list[3] = human_numbers(int(w_list[3]))
             workers_concat.append(w_list)
+        workers_concat = sorted(workers_concat, key=lambda x: int(x[3]), reverse=True)
+        for w in workers_concat:
+            w[3] = human_numbers(int(w[3]))
         return render_template(
             "index.html",
             my_bday=my_bday,

--- a/docker-compose/statistics/app/p2pool_statistics.py
+++ b/docker-compose/statistics/app/p2pool_statistics.py
@@ -60,6 +60,14 @@ def render():
             network_stats = json.loads(reader.read())
         with open("/data/local/stratum", "r") as reader:
             local_stats = json.loads(reader.read())
+        workers = local_stats["workers"][:30] # limit workers output list
+        workers_concat = []
+        for w in workers:
+            w_list = w.split(",")
+            w_list[1] = humanfriendly.format_timespan(int(w_list[1]))
+            w_list[2] = human_numbers(int(w_list[2]))
+            w_list[3] = human_numbers(int(w_list[3]))
+            workers_concat.append(w_list)
         return render_template(
             "index.html",
             my_bday=my_bday,
@@ -67,6 +75,7 @@ def render():
             pool_stats=pool_stats,
             network_stats=network_stats,
             local_stats=local_stats,
+            workers=workers_concat,
         )
     except Exception as e:
         return render_template("oops.html", error=str(e))

--- a/docker-compose/statistics/app/templates/index.html
+++ b/docker-compose/statistics/app/templates/index.html
@@ -64,6 +64,29 @@
                     <td>Block reward share</td>
                     <td>{{ local_stats["block_reward_share_percent"] }}%</td>
                   </tr>
+                  <tr>
+                    <td>Workers
+                      <h6 class="card-subtitle text-muted" style="font-size:80%;">(note: limited to the first 30 workers)</h6>
+                    </td>
+                    <td>
+                      <table style="font-size:65%;">
+                        <tr>
+                          <th>IP:Port</th>
+                          <th>Uptime</th>
+                          <th>Difficulty</th>
+                          <th>Hashrate</th>
+                          <th>Name</th>
+                        </tr>
+                        {% for w in workers %}
+                        <tr>
+                          {% for w_detail in w %}
+                          <td>{{ w_detail }}</td>
+                          {% endfor %}
+                        </tr>
+                        {% endfor %}
+                      </table> 
+                    </td>
+                  </tr> 
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
Now since #278 was merged, the small statistics web server could display worker stats. This PR adds a (preliminary) PoC to add it.
I limited it to 30 workers as of now, but this could be simply changed. 
Also I'm not too happy with the look and feel of the site with the nested table. If someone with more HTML/bootstrap experience wants to chime in?

<img width="600" alt="Bildschirmfoto 2024-01-01 um 11 59 40" src="https://github.com/SChernykh/p2pool/assets/1883533/3f24e014-6628-442b-bbdc-dd01766d0a27">
