### PR TITLE
Update link from unofficial nixos wiki to official one

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ pacman -S p2pool
 
 ### [Nix/NixOS](https://nixos.org)
 
-This is a flake only project. So you have to use [nixUnstable with nix flakes](https://nixos.wiki/wiki/Flakes) to build or install P2Pool. 
+This is a flake only project. So you have to use [nixUnstable with nix flakes](https://wiki.nixos.org/wiki/Flakes) to build or install P2Pool. 
 The commands below use the new flake specific reference-format, so be sure to also set `ca-references` in `--experimental-features`.
 
 Because this project has submodules which are not fixed in _nixUnstable_ yet you have to use the `nix/master` branch:


### PR DESCRIPTION
The readme references the old, unofficial wiki. This PR updates the links to point to the new official wiki source, which will be more properly maintained in the future. It's very much a fandom-wiki situation.