### PR TITLE
Fix stop signal for stats container

### DIFF
--- a/docker-compose/statistics/Dockerfile
+++ b/docker-compose/statistics/Dockerfile
@@ -5,4 +5,6 @@ COPY app /app
 WORKDIR /app
 RUN pip install -r requirements.txt
 
+STOPSIGNAL SIGINT
+
 CMD ["/app/p2pool_statistics.py"]


### PR DESCRIPTION
When running with Docker Compose, `docker compose down`, fails to promptly stop the containers.

This is due to the statistics container not halting when sent SIGTERM by docker, and instead times out and is then killed by docker anyway. As the container is running Python/Flask as PID 1, this receives the SIGTERM but ignores it by default.

There are many ways to fix this, but the simplest is just to get Docker to send SIGINT to this container instead.