### PR TITLE
Correct unit prefix symbol for unit `kilohash per second`

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -344,7 +344,7 @@ template<> struct log::Stream::Entry<Hashrate>
 
 		const double x = static_cast<double>(value.m_data);
 
-		static constexpr const char* units[] = { "H/s", "KH/s", "MH/s", "GH/s", "TH/s", "PH/s", "EH/s" };
+		static constexpr const char* units[] = { "H/s", "kH/s", "MH/s", "GH/s", "TH/s", "PH/s", "EH/s" };
 
 		int n;
 		char buf[32];


### PR DESCRIPTION
The unit prefix **symbols** are case-sensitive. The symbol for the SI unit prefix `kilo-` is lowercased `k`.
