### PR TITLE
Correct unit prefix symbol for unit `mebibyte`

### DIFF
--- a/src/pow_hash.cpp
+++ b/src/pow_hash.cpp
@@ -84,7 +84,7 @@ RandomX_Hasher::RandomX_Hasher(p2pool* pool)
 
 
 	memory_allocated = (memory_allocated + (1 << 20) - 1) >> 20;
-	LOGINFO(1, "allocated " << memory_allocated << " MB");
+	LOGINFO(1, "allocated " << memory_allocated << " MiB");
 }
 
 RandomX_Hasher::~RandomX_Hasher()


### PR DESCRIPTION
The unit prefix symbol to use here should be `Mi` for prefix `mebi-`. Because the code to calculate this number is `... >> 20`, not `... / 1000000`.
