### PR TITLE
API: add `last_share_found_time` in `local/stratum`

### DIFF
--- a/src/stratum_server.h
+++ b/src/stratum_server.h
@@ -203,6 +203,7 @@ private:
 	double m_cumulativeFoundSharesDiff;
 	uint32_t m_totalFoundSidechainShares;
 	uint32_t m_totalFailedSidechainShares;
+	time_t m_lastSidechainShareFoundTime;
 	uint64_t m_totalStratumShares;
 
 	uint64_t m_banTime;


### PR DESCRIPTION
This allows me easily checking *when was my latest pool share found*.

Example result:
```
$ jq . < /tmp/p2pool-api/local/stratum
{
  "hashrate_15m": 11314,
  "hashrate_1h": 18202,
  "hashrate_24h": 16265,
  "total_hashes": 191561440,
  "total_stratum_shares": 848,
  "last_share_found_time": 1749818417,
  "shares_found": 1,
  "shares_failed": 0,
  "average_effort": 6.350,
  "current_effort": 3.200,
  "connections": 4,
  "incoming_connections": 4,
  "block_reward_share_percent": 0.175,
...
```
