### PR TITLE
update Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM debian:12-slim
 
 RUN set -e && \
     apt-get update -q -y --no-install-recommends && \
@@ -25,7 +25,7 @@ RUN git submodule update --init --recursive && \
 
 # ---
 
-FROM ubuntu:20.04
+FROM debian:12-slim
 COPY --from=0 /usr/src/p2pool/build/p2pool /
 
 RUN set -e && \


### PR DESCRIPTION
I tried to build the image locally, but I got timeouts on archive.ubuntu.com when executing apt update, which prevented me to build the image.

I changed the base image to the slimmed down version of debian 12, which works as well and should result in a little leaner image.

After I could build the image successfully on my local machine.

If it has to be ubuntu for some reason, it's advised to use at least ubuntu:24.04 .