### PR TITLE
full share validation via cmdline option

### DIFF
--- a/docs/COMMAND_LINE.MD
+++ b/docs/COMMAND_LINE.MD
@@ -39,6 +39,7 @@
 --rpc-ssl             Enable SSL on RPC connections to the Monero node
 --rpc-ssl-fingerprint base64-encoded fingerprint of the Monero node's certificate (optional, use it for certificate pinning)
 --no-stratum-http     Disable HTTP on Stratum ports
+--full-validation     Enables full share validation / increases CPU usage
 ```
 
 ### Example command line
@@ -116,3 +117,11 @@ openssl x509 -in rpc_ssl.crt -pubkey -noout -inform pem | openssl pkey -pubin -o
 ```
 
 By default, `rpc_ssl.crt` can be found in Monero data directory: `/home/username/.bitmonero/rpc_ssl.crt` on Linux and `C:\ProgramData\bitmonero\rpc_ssl.crt` on Windows.
+
+
+### Full validation
+
+`--full-validation` is a boolean flag and will set the value to true; by default it is false to reduce CPU usage
+
+Enable this if untrusted sources can submit shares to your p2pool server and you want to verify the validity of the shares PoW.  Increases CPU usage.
+This option is for shared mining services, and not neccessary in local setups.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,6 +100,7 @@ void p2pool_usage()
 		"--rpc-ssl-fingerprint base64-encoded fingerprint of the Monero node's certificate (optional, use it for certificate pinning)\n"
 #endif
 		"--no-stratum-http     Disable HTTP on Stratum ports\n"
+		"--full-validation     Enables full share validation / increases CPU usage\n"
 		"--help                Show this help message\n\n"
 		"Example command line:\n\n"
 		"%s --host 127.0.0.1 --rpc-port 18081 --zmq-port 18083 --wallet YOUR_WALLET_ADDRESS --stratum 0.0.0.0:%d --p2p 0.0.0.0:%d\n\n",

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -258,6 +258,11 @@ Params::Params(int argc, char* const argv[])
 		}
 #endif
 
+		if (strcmp(argv[i], "--full-validation") == 0) {
+			m_enableFullValidation = true;
+			ok = true;
+		}
+
 		if (!ok) {
 			// Wait to avoid log messages overlapping with printf() calls and making a mess on screen
 			std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/src/params.h
+++ b/src/params.h
@@ -116,6 +116,7 @@ struct Params
 		uint8_t priv_key[64];
 	};
 #endif
+	bool m_enableFullValidation = false;
 };
 
 } // namespace p2pool

--- a/src/stratum_server.h
+++ b/src/stratum_server.h
@@ -115,7 +115,7 @@ private:
 
 	p2pool* m_pool;
 	bool m_autoDiff;
-
+	bool m_enableFullValidation;
 	struct BlobsData
 	{
 		uint32_t m_extraNonceStart;


### PR DESCRIPTION
adds a command line option to enforce full share validation
this option is only needed on shared mining services, and not needed on local setups where all clients are trusted.
