### PR TITLE
Check for DNS result type before access

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -577,33 +577,28 @@ bool get_dns_txt_records_base(const std::string& host, const Callback<void, cons
 	}
 
 #ifdef _WIN32
-	try {
-		PDNS_RECORD pQueryResults;
-		if (DnsQuery(host.c_str(), DNS_TYPE_TEXT, DNS_QUERY_STANDARD, NULL, &pQueryResults, NULL) != 0) {
-			return false;
+	PDNS_RECORD pQueryResults;
+	if (DnsQuery(host.c_str(), DNS_TYPE_TEXT, DNS_QUERY_STANDARD, NULL, &pQueryResults, NULL) != 0) {
+		return false;
+	}
+
+	for (PDNS_RECORD p = pQueryResults; p; p = p->pNext) {
+		if (p->wType != DNS_TYPE_TEXT) {
+			continue;
 		}
 
-		for (PDNS_RECORD p = pQueryResults; p; p = p->pNext) {
-			if (p->wType != DNS_TYPE_TEXT) {
-				continue;
-			}
-
-			for (size_t j = 0; j < p->Data.TXT.dwStringCount; ++j) {
-				const char* s = p->Data.TXT.pStringArray[j];
-				if (s) {
-					const size_t n = strlen(s);
-					if (n > 0) {
-						callback(s, n);
-					}
+		for (size_t j = 0; j < p->Data.TXT.dwStringCount; ++j) {
+			const char* s = p->Data.TXT.pStringArray[j];
+			if (s) {
+				const size_t n = strlen(s);
+				if (n > 0) {
+					callback(s, n);
 				}
 			}
 		}
+	}
 
-		DnsRecordListFree(pQueryResults, DnsFreeRecordList);
-	}
-	catch (...) {
-		return false;
-	}
+	DnsRecordListFree(pQueryResults, DnsFreeRecordList);
 
 	return true;
 #elif defined(HAVE_RES_QUERY)


### PR DESCRIPTION
Returned dns type in `ppQueryResults` may be something other than provided `wType`, so check `wType` of query result before accessing `Data`.

```
~$ dig TXT seeds-mini.p2pool.io

; <<>> DiG 9.20.9-1-Debian <<>> TXT seeds-mini.p2pool.io
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 57821
;; flags: qr rd ad; QUERY: 1, ANSWER: 5, AUTHORITY: 0, ADDITIONAL: 0
;; WARNING: recursion requested but not available

;; QUESTION SECTION:
;seeds-mini.p2pool.io.          IN      TXT

;; ANSWER SECTION:
seeds-mini.p2pool.io.   0       IN      TXT     "[2a01:4f8:160:91ef::2]:37888,[2a01:4f9:6a:1a0d::2]:37888,65.21.227.114:37888,5.9.17.234:37888,89.233.207.111:37888"
b0.nic.io.              0       IN      A       65.22.161.17
c0.nic.io.              0       IN      A       65.22.162.17
a2.nic.io.              0       IN      A       65.22.163.17
a0.nic.io.              0       IN      A       65.22.160.17
```

Try catch shouldn't be used because it only hides problems.

v4.11 crashes for me shortly after start, but I'm not sure if its because of this. Under debugger, v4.11 doesn't seem to even want to exit `strlen` to proceed into catch clause. When I build master myself, debug and release builds both work without my changes.