### PR TITLE
Edits to Gupax references

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ In order to continue mining on P2Pool, you must update both Monero and P2Pool so
 
 ### GUI for P2Pool
 
-- [Gupax](https://github.com/hinto-janai/gupax) project aims to provide an easy to use cross-platform GUI to configure and run P2Pool & [XMRig](https://github.com/xmrig/xmrig).
+- [Gupax](https://github.com/gupax-io/gupax) project aims to provide an easy to use cross-platform GUI to configure and run P2Pool & [XMRig](https://github.com/xmrig/xmrig).
 
 ### Merge mining
 

--- a/src/p2p_server.cpp
+++ b/src/p2p_server.cpp
@@ -48,9 +48,9 @@ LOG_CATEGORY(P2PServer)
 
 static constexpr char saved_peer_list_file_name[] = "p2pool_peers.txt";
 static constexpr char saved_onion_peer_list_file_name[] = "p2pool_onion_peers.txt";
-static const char* seed_nodes[] = { "seeds.p2pool.io", "main.p2poolpeers.net", "main.gupax.io", "" };
-static const char* seed_nodes_mini[] = { "seeds-mini.p2pool.io", "mini.p2poolpeers.net", "mini.gupax.io", "" };
-static const char* seed_nodes_nano[] = { "seeds-nano.p2pool.io", "nano.p2poolpeers.net", "nano.gupax.io", ""};
+static const char* seed_nodes[] = { "seeds.p2pool.io", "main.p2poolpeers.net", "" };
+static const char* seed_nodes_mini[] = { "seeds-mini.p2pool.io", "mini.p2poolpeers.net", "" };
+static const char* seed_nodes_nano[] = { "seeds-nano.p2pool.io", "nano.p2poolpeers.net", ""};
 
 static constexpr int DEFAULT_BACKLOG = 16;
 static constexpr uint64_t DEFAULT_BAN_TIME = 600;


### PR DESCRIPTION
https://github.com/gupax-io/gupax/issues/137

`gupax.io` still points to p2pool instances I run (although a different server from the original), but I'll be turning them off now. Where the domain points is also up to @Cyrix126 now.