### PR TITLE
Add P2Pool version to status output

### DIFF
--- a/src/side_chain.cpp
+++ b/src/side_chain.cpp
@@ -1079,7 +1079,11 @@ void SideChain::print_status(bool obtain_sidechain_lock) const
 		our_uncles_in_window_chart += ']';
 	}
 
+	const std::string version = p2pool_version();
+	const std::string version_line = version.substr(0, version.find('\n'));
+
 	LOGINFO(0, "status" <<
+		"\nP2Pool version            = " << version_line <<
 		"\nMonero node               = " << m_pool->current_host().m_displayName <<
 		"\nMain chain height         = " << m_pool->block_template().height() <<
 		"\nMain chain hashrate       = " << log::Hashrate(network_hashrate) <<


### PR DESCRIPTION
**Summary:**

Adds the running P2Pool version near the top of the `status` command output.

This reuses the first line of the existing `p2pool_version()` output, so copied diagnostics from `status` include the same version/build information already shown at startup and by the `version` console command.

Example:

```text
SideChain status
P2Pool version            = P2Pool v4.15 (built with GCC/14.2.0 from 3b30129 on May  2 2026)
Monero node               = 127.0.0.1:RPC 18081:ZMQ 18083
Main chain height         = 0
```

**Testing:**

- Built p2pool locally.
- Ran the existing test suite: 36 tests passed.
- Started p2pool, ran `status` in the foreground console, and confirmed the version appears in the SideChain status output.

Fixes #402
